### PR TITLE
Add a flake.nix to the repository

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -26,11 +26,12 @@ To get started with contributing to Cardaminal, follow these steps:
 
 1. Fork the repository on GitHub.
 2. Clone the forked repository to your local machine with `git clone https://github.com/IntersectMBO/cardaminal`.
-3. Navigate to the cloned directory and run `cargo build` to compile the project.
-4. Run `cargo run` to execute the project.
-5. After making your changes, run `cargo test` to ensure all tests pass.
-6. If all tests pass, commit your changes and push your branch to your fork.
-7. Finally, create a pull request in the Cardaminal repository.
+3. Install a rust toolchain and dependencies, or install [nix](https://nixos.org/) and use `nix build` / `nix develop`.
+4. Navigate to the cloned directory and run `cargo build` to compile the project.
+5. Run `cargo run` to execute the project.
+6. After making your changes, run `cargo test` to ensure all tests pass.
+7. If all tests pass, commit your changes and push your branch to your fork.
+8. Finally, create a pull request in the Cardaminal repository.
 
 ## Pull Request Process
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /target
+/.direnv/
+/result

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,94 @@
+{
+  "nodes": {
+    "naersk": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1698420672,
+        "narHash": "sha256-/TdeHMPRjjdJub7p7+w55vyABrsJlt5QkznPYy55vKA=",
+        "owner": "nix-community",
+        "repo": "naersk",
+        "rev": "aeb58d5e8faead8980a807c840232697982d47b9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "ref": "master",
+        "repo": "naersk",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1703068421,
+        "narHash": "sha256-WSw5Faqlw75McIflnl5v7qVD/B3S2sLh+968bpOGrWA=",
+        "path": "/nix/store/lnbafzxw52r0w55hwbcrsdkvk5fymv3l-source",
+        "rev": "d65bceaee0fb1e64363f7871bc43dc1c6ecad99f",
+        "type": "path"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1708501555,
+        "narHash": "sha256-zJaF0RkdIPbh8LTmnpW/E7tZYpqIE+MePzlWwUNob4c=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b50a77c03d640716296021ad58950b1bb0345799",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "naersk": "naersk",
+        "nixpkgs": "nixpkgs_2",
+        "utils": "utils"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1705309234,
+        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,35 @@
+{
+  inputs = {
+    naersk.url = "github:nix-community/naersk/master";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, utils, naersk }:
+    utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+        naersk-lib = pkgs.callPackage naersk { };
+        args = {
+          src = ./.;
+          nativeBuildInputs = with pkgs; [ pkg-config clang ];
+          buildInputs = with pkgs; [ openssl ];
+          LIBCLANG_PATH = "${pkgs.libclang.lib}/lib";
+        };
+      in
+      rec {
+        defaultPackage = naersk-lib.buildPackage args;
+
+        shellArgs = args // {
+          buildInputs = args.buildInputs ++ (with pkgs; [
+            cargo
+            rustc
+            rustfmt
+            rustPackages.clippy
+            rust-analyzer
+          ]);
+          RUST_SRC_PATH = pkgs.rustPlatform.rustLibSrc;
+        };
+        devShell = pkgs.mkShell shellArgs;
+      });
+}


### PR DESCRIPTION
This does allow a full build with `nix build` and get all dependencies for local development in a shell with `nix develop`. From within that shell normal invocations of `cargo` will just work.

This also adds a .envrc with which direnv users can allow a nix shell to be loaded and cached automatically.